### PR TITLE
Overflow/whitespace beside content on small screens

### DIFF
--- a/_scss/_base/_base.scss
+++ b/_scss/_base/_base.scss
@@ -3,6 +3,7 @@ body {
   @include fontsize(12);
   margin: 0;
   padding: 0;
+  overflow-x: hidden;
 
   @include breakpoint(md) {
     @include fontsize(11);


### PR DESCRIPTION
![una](https://cloud.githubusercontent.com/assets/2252884/8760210/ed1b1996-2cd4-11e5-80cc-dbe14e006d90.gif)

There was a little bit of space to the right of the footer/content on small screens (my iPhone 6 haha).

I had some problems with gulp, unable to compile and minify the scss ): so I didn't test this locally, only tried it in the Chrome DevTools. What do you think?

![unafixed](https://cloud.githubusercontent.com/assets/2252884/8760234/d603c004-2cd5-11e5-8582-ea8013df38fa.gif)