### PR TITLE
fixed overflow in safari

### DIFF
--- a/_scss/_base/_base.scss
+++ b/_scss/_base/_base.scss
@@ -1,9 +1,12 @@
+html {
+  overflow-x: hidden;
+}
+
 body {
   @extend %font-copy;
   @include fontsize(12);
   margin: 0;
   padding: 0;
-  overflow-x: hidden;
 
   @include breakpoint(md) {
     @include fontsize(11);


### PR DESCRIPTION
Sorry! It only worked in Chrome/Firefox when it was applied to the body tag :see_no_evil:. When it is applied to the html tag, it works in `[Safari, Chrome, Firefox]`.. Added into `_base/base` so as to not mess with `_utils/reset`.

Thanks though, this is helping have a better understanding of the Github flow :)

![una_git_status](https://cloud.githubusercontent.com/assets/2252884/8762704/aa79b08a-2d46-11e5-86d6-776d350a06e4.png)
