### PR TITLE
Fix the path to the favicon

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="description" content="Thoughts about front-end development and design. And probably other ramblings by Una Kravets.">
     <link rel="manifest" href="/manifest.webmanifest">
-    <link rel="icon" type="image/png" href="images/favicon.png">
+    <link rel="icon" type="image/png" href="/images/favicon.png">
 
     <!-- RSS -->
     <link rel="alternate" type="application/rss+xml" name="{{ site.name }}" title="{{ site.name }}" href="{{ site.url }}/feed.xml">


### PR DESCRIPTION
Looks like Favicon url gives 404 on pages of articles. For example here :https://una.im/rethinking-responsive/