### PR TITLE
Switch the repo to the Pa11y org version

### DIFF
--- a/_posts/blog/2016-05-04-pa11ydash.md
+++ b/_posts/blog/2016-05-04-pa11ydash.md
@@ -91,11 +91,11 @@ To make sure its on your system use `phantomjs -v`.
 
 ## Step 5: Fork, Clone, Install Dependencies
 
-Your visible sites are in `opt/` with this setup, so you’ll want to get into that directory with (from the root) `cd ~/../opt`. Once there, you may see the existing demo directory called *mean*. Clone the [pa11y-dashboard](https://github.com/springernature/pa11y-dashboard) repo, or your fork of it (which I'd recommend for customization), with `git clone https://github.com/springernature/pa11y-dashboard.git` (or your cloned address).
+Your visible sites are in `opt/` with this setup, so you’ll want to get into that directory with (from the root) `cd ~/../opt`. Once there, you may see the existing demo directory called *mean*. Clone the [pa11y-dashboard](https://github.com/pa11y/dashboard) repo, or your fork of it (which I'd recommend for customization), with `git clone https://github.com/pa11y/dashboard.git` (or your cloned address).
 
 Then cd into *that* directory with `cd pa11y-dashboard` and run `npm install` (remember Node is already installed because *one-step app* thing DigitalOcean gave us — yayyyy &mdash; but we still need to set up the repo itself).
 
-Make sure you follow the [pa11y-dashboard](https://github.com/springernature/pa11y-dashboard) instructions, including the following commands:
+Make sure you follow the [pa11y-dashboard](https://github.com/pa11y/dashboard) instructions, including the following commands:
 
 ```
 cp config/development.sample.json config/development.json


### PR DESCRIPTION
Hi Una! 👋 Requesting a small tweak to your excellent post about
Pa11y Dashboard.

This currently points at the SpringerNature fork of Pa11y Dashboard
which doesn't work. It's our bad – `springernature/pa11y-dashboard`
used to redirect to `pa11y/dashboard` but then the company forked it.

Now it's confusing to anyone working through this post because they
potentially start working from a repo with loads of Springer Nature
specific changes, and the thing won't run 

Sorry if anyone's stumbled on this!