### PR TITLE
fix broken 2019-01-09-houdini post page

### DIFF
--- a/_posts/blog/2019-03-26-mapreducefilter.html
+++ b/_posts/blog/2019-03-26-mapreducefilter.html
@@ -1,16 +1,15 @@
 ---
 layout: post
 title: "An Illustrated (and Musical) Guide to Map, Reduce, and Filter Array Methods"
-permalink: /houdini-horizons/
-date: '2019-01-09'
+permalink: /illustrated-map-reduce-filter/
+date: '2019-03-26'
 comments: true
 tags:
-- Houdini
-- Paint API
-- Browser API
-- CSS
-- Exprimental
-- Future
+- arrays
+- filter
+- javascript
+- map
+- reduce
 subtitle: "Map, reduce, and filter are three very useful array methods in JavaScript that give developers a ton of power. This post makes them a little easier to understand."
 link-out: https://css-tricks.com/an-illustrated-and-musical-guide-to-map-reduce-and-filter-array-methods/
 ---


### PR DESCRIPTION
due to the incorrect meta data in the blog post _An Illustrated (and Musical) Guide to Map, Reduce, and Filter Array Methods_, it had the same permaurl as the CSS houdini post, breaking the Houdini post's page.